### PR TITLE
Include the license in a standard way

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+#License
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    data_files = [("", ["LICENSE.txt"])],
     long_description = """\
 systemd Service Notification
 


### PR DESCRIPTION
Using data_files causes LICENSE.txt to be installed in prefix which could clobber another file. Using MANIFEST will include it in the tarball without this risk.