### PR TITLE
setup.py: switch to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 VERSION='0.3.2'
 


### PR DESCRIPTION
In Python 3.10, 'distutils' is deprecated and is slated for removal in
Python 3.12.

Switch from distutils.core to setuptools. This also allows the 'wheel'
binary archive format to be built with 'setup.py bdist_wheel'.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>